### PR TITLE
カメラデバイスを選択できるようにする

### DIFF
--- a/client/testModule/electron/src/main/main.js
+++ b/client/testModule/electron/src/main/main.js
@@ -31,7 +31,7 @@ app.setAppUserModelId("com.electron.vega")
 
 function createWindow() {
     const win = new BrowserWindow({
-        width: 800,
+        width: 1200,
         height: 600,
         webPreferences: {
             nodeIntegration: true

--- a/client/testModule/electron/src/renderer/head_pose_estimation.js
+++ b/client/testModule/electron/src/renderer/head_pose_estimation.js
@@ -1,15 +1,34 @@
 const net = require('net')
 const request = require('request');
 
+if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
+	console.log("enumerateDevices() not supported.");
+}
+
+// List cameras
+navigator.mediaDevices.enumerateDevices().then(devices => {
+    const sel = document.getElementById('camera-device-id');
+    devices.forEach(function(device) {
+        console.log(device.kind + ": " + device.label + " id = " + device.deviceId);
+        if (device.kind == 'videoinput') {
+            var opt = document.createElement('option');
+            opt.appendChild(document.createTextNode(device.label));
+            opt.value = device.deviceId;
+            sel.appendChild(opt);
+        }
+    });
+}).catch(err => console.log(err.name + ": " + err.message));
+
+const myDeviceId = document.getElementById('camera-device-id').value;
+
 navigator.mediaDevices.getUserMedia({
-    video: true,
+    video: {deviceId: myDeviceId},
     audio: false,
 }).then(stream => {
     const video = document.getElementById('video');
     video.srcObject = stream;
-});
-
-video.play();
+    video.play();
+}).catch(error => alert('Cannot connect to camera: ' + error));
 
 const faceapi = require('face-api.js')
 

--- a/client/testModule/electron/src/renderer/index.html
+++ b/client/testModule/electron/src/renderer/index.html
@@ -6,6 +6,7 @@
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' 'unsafe-eval';" />
 </head>
 <body>
+    <select name="camera-device-id" id="camera-device-id"></select>
     <div style="position: relative;">
         <video id="video" width="640" height="480" style="transform: scaleX(-1);"></video>
         <canvas id="canvas1" width="640" height="480" style="position: absolute; top: 0px; left: 0px; transform: scaleX(-1);"></canvas>


### PR DESCRIPTION
外部接続のUSBカメラが認識されなかったので、カメラデバイスを列挙し選択できるようにしました。
学科PCのUbuntuでも動作確認取れました。

electronフォルダでnpm startしてください。
今後のアプリの起動方法はpython main.pyではなく、npm startに統一していく予定です。