### PR TITLE
change ssh check from name to command

### DIFF
--- a/client/testModule/src/renderer/process/packet.js
+++ b/client/testModule/src/renderer/process/packet.js
@@ -124,13 +124,13 @@ const testSSH = async () => {
                 }
             });
         
-            const checkProcessName = (name) => {
+            const checkProcessName = (process) => {
                 // Chrome remote desktop@Windows
-                if (/.*(remote|remoting).*/.test(name)) {
+                if (/.*(remote|remoting).*/.test(process.name)) {
                     return true;
                 }
                 // ssh@Ubuntu
-                else if (/.*sshd:.*@.*/.test(name)) {
+                else if (/.*sshd: .*/.test(process.command)) {
                     return true;
                 }
                 return false;
@@ -139,7 +139,7 @@ const testSSH = async () => {
             setInterval(async () => {
                 // process name filtering
                 const processList = (await si.processes()).list;
-                const alertProcessList = processList.filter((process) => checkProcessName(process.name));
+                const alertProcessList = processList.filter((process) => checkProcessName(process));
                 if (alertProcessList.length === 0) {
                     ipc.of.sshserver.emit('message', {
                         title: 'ok',


### PR DESCRIPTION
### bug
sshアクセスをしても検出が出来ない

### 原因
現在使っているsysteminformationではsshdまでしかプロセス名が存在せず、commandを取る必要があったため。

### 変更内容
sshプロセスチェックで正規表現を適切に変更しつつname->commandに変更