### PR TITLE
examページにアラートと試験監督からのメッセージを表示

### DIFF
--- a/client/testModule/src/main/main.js
+++ b/client/testModule/src/main/main.js
@@ -8,8 +8,10 @@ const path = require('path')
 
 app.setAppUserModelId("com.electron.satori")
 
+let win;
+
 function createWindow() {
-    const win = new BrowserWindow({
+    win = new BrowserWindow({
         width: 1080,
         minWidth: 680,
         height: 840,
@@ -147,6 +149,12 @@ connection.onerror = function() {
 
 connection.onmessage = function(e) {
     console.log(e.data);
+    const notification = {
+        title: '試験監督からの新着メッセージ',
+        body: e.data
+    }
+    new Notification(notification).show()
+    win.webContents.send('proctor-message', e.data)
 };
 
 connection.onclose = function() {

--- a/client/testModule/src/renderer/active_window.js
+++ b/client/testModule/src/renderer/active_window.js
@@ -17,6 +17,7 @@ const active_window_interval = setInterval(function() {
                 alert: 2,
                 description: 'Changed to ' + current_active_app_title 
             });
+            add_warning('画面が' + current_active_app_title + 'に変わりました')
         } else {
             active_window_counter += 1
             if (active_window_counter == 4) {

--- a/client/testModule/src/renderer/exam.html
+++ b/client/testModule/src/renderer/exam.html
@@ -35,11 +35,19 @@
             <div class="box">
                 <p><b>注意</b></p>
                 <hr>
+                <div style="max-height: 120px;overflow: scroll;">
+                    <ul id="warning">
+                    </ul>
+                </div>
             </div>
 
             <div class="box">
                 <p><b>試験監督からのメッセージ</b></p>
                 <hr>
+                <div style="max-height: 120px;overflow: scroll;">
+                    <ul id="proctor-message">
+                    </ul>
+                </div>
             </div>
         </div>
 

--- a/client/testModule/src/renderer/init.js
+++ b/client/testModule/src/renderer/init.js
@@ -1,3 +1,19 @@
 const { ipcRenderer } = require('electron')
 
 ipcRenderer.send('dual_display_detect', { description: 'start dual display detect' });
+
+const add_warning = (warning_message) => {
+  let warning = document.getElementById('warning')
+  let new_warning = document.createElement('li')
+  new_warning.innerText = warning_message
+  warning.appendChild(new_warning)
+  new_warning.scrollIntoView()
+}
+
+ipcRenderer.on('proctor-message', (event, message) => {
+  let proctor = document.getElementById('proctor-message')
+  let new_message = document.createElement('li')
+  new_message.innerText = message
+  proctor.appendChild(new_message)
+  new_message.scrollIntoView()
+})

--- a/client/testModule/src/renderer/styles/exam.css
+++ b/client/testModule/src/renderer/styles/exam.css
@@ -27,3 +27,13 @@ button#exam_finish {
   50% { background-color: rgb(255, 145, 0); }
   100% { background-color: #ff0000; }
 }
+
+li {
+  list-style-type: none;
+  background-color: #fff;
+  width: 90%;
+  color: red;
+  height: 100%;
+  padding: 10px;
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
examページの「注意」と「試験監督からの新着メッセージ」に情報が追加されるように実装。
「注意」には、アラートレベル１か２の注意が自動的に追記。
「試験監督からのメッセージ」には、試験監督のフロントエンド画面からメッセージを送信すると受信され、表示される。

![Screenshot from 2020-11-28 07-04-41](https://user-images.githubusercontent.com/5180742/100486673-416cfc80-3148-11eb-9b23-13f4697baa57.png)
